### PR TITLE
Fix for tr and find on macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -172,7 +172,7 @@ if test -n "$watch" -o -n "$w"; then
     declare -A lasttimes
     while sleep 1; do
         # ignores hidden files and dirs (./.*), the www and docs folders, and VIM .swp files
-        for file in `find -type f | grep -v "^\./\." | grep -v "./www/.*" | grep -v "./docs/.*" | grep -v "\.swp$"`;  do
+        for file in `find . -type f | grep -v "^\./\." | grep -v "./www/.*" | grep -v "./docs/.*" | grep -v "\.swp$"`; do
             time=`stat $stat_find_param %Z "$file"`
 
             if [ -z ${lasttimes[$file]} ]; then


### PR DESCRIPTION
`tr` on the mac doesn't like the truly random stuff from urandom.
This works around that so pages can be built again.